### PR TITLE
Implement CERN loader for slow page loading

### DIFF
--- a/assets/css/main.css
+++ b/assets/css/main.css
@@ -4454,3 +4454,52 @@ body.is-mobile #header #logo-container {
 	text-decoration: none;
 	text-transform: uppercase;
 }
+
+/* CERN Loader Styles */
+#cern-loader {
+	position: fixed;
+	top: 0;
+	left: 0;
+	width: 100%;
+	height: 100%;
+	background-color: rgba(46, 56, 66, 0.92);
+	backdrop-filter: blur(3px);
+	display: flex;
+	align-items: center;
+	justify-content: center;
+	z-index: 99999;
+	transition: opacity 0.15s ease-out, visibility 0.15s ease-out;
+}
+
+#cern-loader.loaded {
+	opacity: 0;
+	visibility: hidden;
+}
+
+.cern-loader-content {
+	text-align: center;
+	display: flex;
+	align-items: center;
+	justify-content: center;
+}
+
+.cern-loader-gif {
+	width: 140px;
+	height: 140px;
+	filter: brightness(1.1) contrast(1.1);
+}
+
+/* Responsive loader adjustments */
+@media screen and (max-width: 736px) {
+	.cern-loader-gif {
+		width: 100px;
+		height: 90px;
+	}
+}
+
+@media screen and (max-width: 480px) {
+	.cern-loader-gif {
+		width: 70px;
+		height: 70px;
+	}
+}

--- a/assets/js/main.js
+++ b/assets/js/main.js
@@ -21,11 +21,58 @@
 			xsmall:   [ null,      '480px'  ]
 		});
 
+	// CERN Loader functionality - (slow loading)
+		var loaderCreated = false;
+		var pageLoadStart = Date.now();
+		
+		function createCERNLoader() {
+			// Only create if it doesn't exist and hasn't been created yet
+			if (!loaderCreated && $('#cern-loader').length === 0) {
+				var loaderHTML = '<div id="cern-loader">' +
+					'<div class="cern-loader-content">' +
+					'<img src="images/loader.gif" alt="CERN Loader" class="cern-loader-gif">' +
+					'</div>' +
+					'</div>';
+				$body.prepend(loaderHTML);
+				loaderCreated = true;
+			}
+		}
+		
+		function hideCERNLoader() {
+			var $loader = $('#cern-loader');
+			if ($loader.length && !$loader.hasClass('loaded')) {
+				$loader.addClass('loaded');
+				// Remove loader from DOM after transition
+				window.setTimeout(function() {
+					$loader.remove();
+					loaderCreated = false;
+				}, 150);
+			}
+		}
+		
+		// Only show loader if page takes longer than 800ms to load
+		var loaderTimeout = window.setTimeout(function() {
+			// Check if page is still loading after 800ms
+			if ($body.hasClass('is-preload')) {
+				createCERNLoader();
+			}
+		}, 800);
+		
+		// Hide loader if it takes too long (fallback - 5 seconds)
+		var maxTimeout = window.setTimeout(function() {
+			hideCERNLoader();
+		}, 5000);
+
 	// Play initial animations on page load.
 		$window.on('load', function() {
+			var loadTime = Date.now() - pageLoadStart;
+			
 			window.setTimeout(function() {
 				$body.removeClass('is-preload');
-			}, 100);
+				clearTimeout(loaderTimeout);
+				clearTimeout(maxTimeout);
+				hideCERNLoader();
+			}, 50);
 		});
 
 	// Mobile?


### PR DESCRIPTION
Fixes #71 
Added a CERN-style loading animation to the Rucio website. The loader shows up only if the page takes more than 800ms to load.

Example:

https://github.com/user-attachments/assets/c6ca6006-240b-40f2-abf6-2d66c7925cab


Note: Since the site is static and lightweight, the loader usually won’t appear. I lowered the delay temporarily while testing to confirm that it works, as shown in the video.
The loader doesn’t really fit our website’s use case, but it’s required by the [CERN design guidelines](https://design-guidelines.web.cern.ch/guidelines/guidelines-cern-websites). 