### PR TITLE
Add event banner for 8th Rucio Community Workshop

### DIFF
--- a/index.html
+++ b/index.html
@@ -75,6 +75,11 @@
         <h2> <img src="images/wide_logo2.png" />
         </h2>
         <p>Scientific data management</p>
+        <p style="margin-top: 2em; font-size: 1em; font-weight: 500; color: #ffffff; text-shadow: 0 1px 3px rgba(0, 0, 0, 0.5);">
+          <a href="https://indico.cern.ch/event/1545309/" style="color: #ffffff; text-decoration: none; border-bottom: 2px solid rgba(255, 255, 255, 0.5); padding-bottom: 3px; transition: all 0.3s ease; text-shadow: 0 1px 3px rgba(0, 0, 0, 0.5);" onmouseover="this.style.borderBottom='2px solid #ffffff'; this.style.transform='translateY(-1px)'" onmouseout="this.style.borderBottom='2px solid rgba(255, 255, 255, 0.5)'; this.style.transform='translateY(0)'">
+          8th Rucio Community Workshop • Nov 3-7, 2025 • SKAO Global HQ, UK
+          </a>
+        </p>
       </div>
 
       <a href="#one" class="more scrolly">Learn More</a>


### PR DESCRIPTION
Fixes #81 

Screenshots: 
<img width="1487" height="585" alt="image" src="https://github.com/user-attachments/assets/fc69adaf-2aae-4f26-8b5f-f6f35e4ee768" />

Note:
Used inline styling and CSS so this banner can be easily removed as a whole component after the event. This design felt more cleaner than putting a dark background behind the text of event.