### PR TITLE
Migrate Communication Section from Rucio Docs to Rucio Website | Refactoring components

### DIFF
--- a/assets/js/footer.js
+++ b/assets/js/footer.js
@@ -1,0 +1,37 @@
+// Footer component for Rucio website
+function createFooter() {
+    const footerHTML = `
+    <footer id="footer">
+      <ul class="icons">
+        <li><a href="https://github.com/rucio" class="icon brands fa-github"><span class="label">GitHub</span></a></li>
+        <li><a href="https://fosstodon.org/@rucio" class="icon brands fa-mastodon"><span class="label">Mastodon</span></a></li>
+        <li><a href="contact.html" class="icon solid fa-comments"><span class="label">Contact Us</span></a></li>
+        <li><a href="mailto:rucio-contact@cern.ch" class="icon solid fa-envelope"><span class="label">Email</span></a>
+        </li>
+      </ul>
+      <div class="cern-footer">
+        <a href="https://home.cern" class="cern-logo-link" title="CERN - Accelerating Science">
+          <img src="images/LogoOutline-White.svg" alt="CERN" class="cern-logo" />
+        </a>
+      </div>
+      <ul class="copyright">
+        <li>Website template by: <a href="http://html5up.net">HTML5 UP</a></li>
+        <li>Background image by: <a href="https://cds.cern.ch/record/1489958">CERN</a></li>
+      </ul>
+    </footer>`;
+    
+    return footerHTML;
+}
+
+// Function to inject footer into the page
+function injectFooter() {
+    const footerContainer = document.getElementById('footer-container');
+    if (footerContainer) {
+        footerContainer.innerHTML = createFooter();
+    }
+}
+
+// Auto-inject footer when DOM is loaded
+document.addEventListener('DOMContentLoaded', function() {
+    injectFooter();
+});

--- a/assets/js/header.js
+++ b/assets/js/header.js
@@ -1,0 +1,74 @@
+// Header component for Rucio website
+function createHeader(className = '') {
+    const headerHTML = `
+    <header id="header" class="${className}">
+      <a href="index.html">
+        <span id="logo-container">
+          <img src='images/wide_logo2.png' />
+        </span>
+      </a>
+
+      <nav id="nav-desktop">
+        <ul>
+          <li><a class="icon solid fa-code" href="https://github.com/rucio/rucio">&nbsp;Source</a></li>
+          <li>-</li>
+          <li><a class="icon solid fa-file-archive" href="https://rucio.cern.ch/documentation">&nbsp;Documentation</a></li>
+          <li>-</li>
+          <li><a class="icon solid fa-users" href="team.html">&nbsp;Team</a></li>
+          <li>-</li>
+          <li><a class="icon solid fa-globe" href="community.html">&nbsp;Community</a></li>
+          <li>-</li>
+          <li><a class="icon solid fa-comments" href="contact.html">&nbsp;Communication</a></li>
+          <li>-</li>
+          <li><a class="icon solid fa-book" href="publications.html">&nbsp;Publications</a></li>
+          <li>-</li>
+          <li><a class="icon solid fa-calendar" href="events.html">&nbsp;Events</a></li>
+        </ul>
+      </nav>
+      <nav id="nav">
+        <ul>
+          <li class="special">
+            <a href="#menu" class="menuToggle"></a>
+            <div id="menu">
+              <ul>
+                <li><a class="icon solid fa-code" href="https://github.com/rucio/rucio">&nbsp;Source</a></li>
+                <li><a class="icon solid fa-file-archive"
+                    href="https://rucio.cern.ch/documentation">&nbsp;Documentation</a></li>
+                <li><a class="icon solid fa-users" href="team.html">&nbsp;Team</a></li>
+                <li><a class="icon solid fa-globe" href="community.html">&nbsp;Community</a></li>
+                <li><a class="icon solid fa-comments" href="contact.html">&nbsp;Communication</a></li>
+                <li><a class="icon solid fa-book" href="publications.html">&nbsp;Publications</a></li>
+                <li><a class="icon solid fa-calendar" href="events.html">&nbsp;Events</a></li>
+              </ul>
+            </div>
+          </li>
+        </ul>
+      </nav>
+    </header>`;
+    
+    return headerHTML;
+}
+
+// Function to inject header into the page
+function injectHeader(className = '') {
+    const headerContainer = document.getElementById('header-container');
+    if (headerContainer) {
+        headerContainer.innerHTML = createHeader(className);
+    }
+}
+
+// Function to set header class based on page type
+function setHeaderClass(className = '') {
+    const header = document.getElementById('header');
+    if (header && className) {
+        header.className = className;
+    }
+}
+
+// Auto-inject header when DOM is loaded
+document.addEventListener('DOMContentLoaded', function() {
+    // Check if this is the index page (home page) and set alt class
+    const isHomePage = window.location.pathname === '/' || window.location.pathname.endsWith('/index.html');
+    const headerClass = isHomePage ? 'alt' : '';
+    injectHeader(headerClass);
+});

--- a/assets/js/scripts.js
+++ b/assets/js/scripts.js
@@ -1,0 +1,54 @@
+// Common scripts loader for Rucio website
+function loadCommonScripts() {
+    const scripts = [
+        'assets/js/cern-toolbar.js',
+        'assets/js/jquery.min.js',
+        'assets/js/jquery.scrollex.min.js',
+        'assets/js/jquery.scrolly.min.js',
+        'assets/js/browser.min.js',
+        'assets/js/breakpoints.min.js',
+        'assets/js/util.js',
+        'assets/js/main.js'
+    ];
+
+    // Load scripts sequentially to maintain dependencies
+    function loadScript(index) {
+        if (index >= scripts.length) {
+            return;
+        }
+
+        const script = document.createElement('script');
+        script.src = scripts[index];
+        script.onload = function() {
+            loadScript(index + 1);
+        };
+        script.onerror = function() {
+            console.error('Failed to load script:', scripts[index]);
+            loadScript(index + 1); // Continue loading next script even if one fails
+        };
+        document.head.appendChild(script);
+    }
+
+    loadScript(0);
+}
+
+// Function to inject script tags into the page
+function injectScripts() {
+    const scriptsContainer = document.getElementById('scripts-container');
+    if (scriptsContainer) {
+        loadCommonScripts();
+        
+        // Add IE conditional comment script if needed
+        const ieScript = document.createElement('script');
+        ieScript.innerHTML = '<!--[if lte IE 8]><script src="assets/js/ie/respond.min.js"></script><![endif]-->';
+        scriptsContainer.appendChild(ieScript);
+    } else {
+        // If no scripts container found, load scripts directly
+        loadCommonScripts();
+    }
+}
+
+// Auto-inject scripts when DOM is loaded
+document.addEventListener('DOMContentLoaded', function() {
+    injectScripts();
+});

--- a/community.html
+++ b/community.html
@@ -38,7 +38,7 @@
           <li>-</li>
           <li><a class="icon solid fa-globe" href="community.html">&nbsp;Community</a></li>
           <li>-</li>
-          <li><a class="icon solid fa-comments" href="https://rucio.cern.ch/documentation/contact_us">&nbsp;Communication</a></li>
+          <li><a class="icon solid fa-comments" href="contact.html">&nbsp;Communication</a></li>
           <li>-</li>
           <li><a class="icon solid fa-book" href="publications.html">&nbsp;Publications</a></li>
           <li>-</li>
@@ -55,7 +55,7 @@
                 <li><a class="icon solid fa-file-archive" href="https://rucio.cern.ch/documentation">&nbsp;Documentation</a></li>
                 <li><a class="icon solid fa-users" href="team.html">&nbsp;Team</a></li>
                 <li><a class="icon solid fa-globe" href="community.html">&nbsp;Community</a></li>
-                <li><a class="icon solid fa-comments" href="https://rucio.cern.ch/documentation/contact_us">&nbsp;Communication</a></li>
+                <li><a class="icon solid fa-comments" href="contact.html">&nbsp;Contact</a></li>
                 <li><a class="icon solid fa-book" href="publications.html">&nbsp;Publications</a></li>
                 <li><a class="icon solid fa-calendar" href="events.html">&nbsp;Events</a></li>
               </ul>
@@ -110,7 +110,7 @@
             </p>
           </header>
           <ul class="actions vertical">
-            <li><a href="https://rucio.cern.ch/documentation/contact_us" class="button special primary">Contact us</a></li>
+            <li><a href="contact.html" class="button special primary">Contact us</a></li>
           </ul>
 
         </div>

--- a/community.html
+++ b/community.html
@@ -21,49 +21,7 @@
   <div id="page-wrapper">
 
     <!-- Header -->
-    <header id="header">
-      <a href="index.html">
-        <span id="logo-container">
-          <img src='images/wide_logo2.png' />
-        </span>
-      </a>
-
-      <nav id="nav-desktop">
-        <ul>
-          <li><a class="icon solid fa-code" href="https://github.com/rucio/rucio">&nbsp;Source</a></li>
-          <li>-</li>
-          <li><a class="icon solid fa-file-archive" href="https://rucio.cern.ch/documentation">&nbsp;Documentation</a></li>
-          <li>-</li>
-          <li><a class="icon solid fa-users" href="team.html">&nbsp;Team</a></li>
-          <li>-</li>
-          <li><a class="icon solid fa-globe" href="community.html">&nbsp;Community</a></li>
-          <li>-</li>
-          <li><a class="icon solid fa-comments" href="contact.html">&nbsp;Communication</a></li>
-          <li>-</li>
-          <li><a class="icon solid fa-book" href="publications.html">&nbsp;Publications</a></li>
-          <li>-</li>
-          <li><a class="icon solid fa-calendar" href="events.html">&nbsp;Events</a></li>
-        </ul>
-      </nav>
-      <nav id="nav">
-        <ul>
-          <li class="special">
-            <a href="#menu" class="menuToggle"></a>
-            <div id="menu">
-              <ul> 
-                <li><a class="icon solid fa-code" href="https://github.com/rucio/rucio">&nbsp;Source</a></li>
-                <li><a class="icon solid fa-file-archive" href="https://rucio.cern.ch/documentation">&nbsp;Documentation</a></li>
-                <li><a class="icon solid fa-users" href="team.html">&nbsp;Team</a></li>
-                <li><a class="icon solid fa-globe" href="community.html">&nbsp;Community</a></li>
-                <li><a class="icon solid fa-comments" href="contact.html">&nbsp;Contact</a></li>
-                <li><a class="icon solid fa-book" href="publications.html">&nbsp;Publications</a></li>
-                <li><a class="icon solid fa-calendar" href="events.html">&nbsp;Events</a></li>
-              </ul>
-            </div>
-          </li>
-        </ul>
-      </nav>
-    </header>
+    <div id="header-container"></div>
 
     <section id="community" class="wrapper style5">
       <div class="inner">
@@ -117,36 +75,14 @@
       </section>
 
       <!-- Footer -->
-      <footer id="footer">
-        <ul class="icons">
-          <li><a href="https://github.com/rucio" class="icon brands fa-github"><span class="label">GitHub</span></a></li>
-          <li><a href="https://fosstodon.org/@rucio" class="icon brands fa-mastodon"><span class="label">GitHub</span></a></li>
-		  <li><a href="http://rucio.cern.ch/documentation/contact_us" class="icon solid fa-comments"><span class="label">Contact Us</span></a></li>
-          <li><a href="mailto:rucio-contact@cern.ch" class="icon solid fa-envelope"><span class="label">Email</span></a></li>
-        </ul>
-        <div class="cern-footer">
-          <a href="https://home.cern" class="cern-logo-link" title="CERN - Accelerating Science">
-            <img src="images/LogoOutline-White.svg" alt="CERN" class="cern-logo" />
-          </a>
-        </div>
-        <ul class="copyright">
-          <li>Website template by: <a href="https://html5up.net">HTML5 UP</a></li>
-          <li>Background image by: <a href="https://cds.cern.ch/record/1489958">CERN</a></li>
-        </ul>
-      </footer>
+      <div id="footer-container"></div>
 
     </section>
   </div>
 	<!-- Scripts -->
-    <script src="assets/js/cern-toolbar.js"></script>
-    <script src="assets/js/jquery.min.js"></script>
-    <script src="assets/js/jquery.scrollex.min.js"></script>
-    <script src="assets/js/jquery.scrolly.min.js"></script>
-    <script src="assets/js/browser.min.js"></script>
-    <script src="assets/js/breakpoints.min.js"></script>
-    <script src="assets/js/util.js"></script>
-    <script src="assets/js/main.js"></script>
-    <!--[if lte IE 8]><script src="assets/js/ie/respond.min.js"></script><![endif]-->
+    <script src="assets/js/header.js"></script>
+    <script src="assets/js/footer.js"></script>
+    <script src="assets/js/scripts.js"></script>
 
 </body>
 

--- a/contact.html
+++ b/contact.html
@@ -50,20 +50,6 @@
 
       </div>
 
-      <!-- CTA -->
-      <section id="cta" class="wrapper style5">
-        <div class="inner">
-          <header>
-            <h2>Get in touch</h2>
-            <p>We are always happy to chat. You can drop us a mail and we will reply as quickly as possible.
-            </p>
-          </header>
-          <ul class="actions vertical">
-            <li><a href="contact.html" class="button special primary">Contact us</a></li>
-          </ul>
-
-        </div>
-      </section>
 
       <!-- Footer -->
       <div id="footer-container"></div>

--- a/contact.html
+++ b/contact.html
@@ -1,0 +1,146 @@
+<!DOCTYPE HTML>
+<!--
+    Spectral by HTML5 UP
+    html5up.net | @ajlkn
+    Free for personal and commercial use under the CCA 3.0 license (html5up.net/license)
+  -->
+<html>
+
+<head>
+  <title>Rucio - Scientific Data Management :: Communication</title>
+  <meta charset="utf-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1, user-scalable=no" />
+  <link rel="stylesheet" href="assets/css/main.css" />
+  <noscript><link rel="stylesheet" href="assets/css/noscript.css" /></noscript>
+  <link rel="me" href="https://fosstodon.org/@rucio" />
+</head>
+
+<body class="landing">
+
+  <!-- Page Wrapper -->
+  <div id="page-wrapper">
+
+    <!-- Header -->
+    <header id="header">
+      <a href="index.html">
+        <span id="logo-container">
+          <img src='images/wide_logo2.png' />
+        </span>
+      </a>
+
+      <nav id="nav-desktop">
+        <ul>
+          <li><a class="icon solid fa-code" href="https://github.com/rucio/rucio">&nbsp;Source</a></li>
+          <li>-</li>
+          <li><a class="icon solid fa-file-archive" href="https://rucio.cern.ch/documentation">&nbsp;Documentation</a></li>
+          <li>-</li>
+          <li><a class="icon solid fa-users" href="team.html">&nbsp;Team</a></li>
+          <li>-</li>
+          <li><a class="icon solid fa-globe" href="community.html">&nbsp;Community</a></li>
+          <li>-</li>
+          <li><a class="icon solid fa-comments" href="contact.html">&nbsp;Communication</a></li>
+          <li>-</li>
+          <li><a class="icon solid fa-book" href="publications.html">&nbsp;Publications</a></li>
+          <li>-</li>
+          <li><a class="icon solid fa-calendar" href="events.html">&nbsp;Events</a></li>
+        </ul>
+      </nav>
+      <nav id="nav">
+        <ul>
+          <li class="special">
+            <a href="#menu" class="menuToggle"></a>
+            <div id="menu">
+              <ul> 
+                <li><a class="icon solid fa-code" href="https://github.com/rucio/rucio">&nbsp;Source</a></li>
+                <li><a class="icon solid fa-file-archive" href="https://rucio.cern.ch/documentation">&nbsp;Documentation</a></li>
+                <li><a class="icon solid fa-users" href="team.html">&nbsp;Team</a></li>
+                <li><a class="icon solid fa-globe" href="community.html">&nbsp;Community</a></li>
+                <li><a class="icon solid fa-comments" href="contact.html">&nbsp;Communication</a></li>
+                <li><a class="icon solid fa-book" href="publications.html">&nbsp;Publications</a></li>
+                <li><a class="icon solid fa-calendar" href="events.html">&nbsp;Events</a></li>
+              </ul>
+            </div>
+          </li>
+        </ul>
+      </nav>
+    </header>
+
+    <section id="communication" class="wrapper style5" style="margin-top: 4em;">
+      <div class="inner">
+        <header class="major" style="margin-bottom: 1em;">
+          <h2>Contact us</h2>
+          <p>We know getting started can be difficult, which is why our developers are always happy to help out! Reach out to us on any of the below channels for any assistance with Rucio.</p>
+        </header>
+          <h2>Chat with us <a class="icon solid fa-comments" href="https://rucio.cern.ch/documentation/join_rucio_mattermost"></a></h2>
+          <p>We have a dedicated Mattermost team for questions, support, news, development updates and all things Rucio and you can be a part of it too! <a href="https://rucio.cern.ch/documentation/join_rucio_mattermost">Join our Mattermost</a>.</p>
+
+
+          <h2>Weekly Rucio meeting <a class="icon solid fa-calendar" href="https://indico.cern.ch/category/10588/"></a></h2>
+          <p>The Rucio community gathers for a meeting every Thursday at 3 PM CEST to discuss community news, operational issues and questions, as well as ongoing & further contributions by the development team. The meeting is open to the public and you can view the schedule <a href="https://indico.cern.ch/category/10588/">here</a>.</p>
+
+
+          <h2>Rucio news mailing list <a class="icon solid fa-envelope" href="mailto:rucio-news@cern.ch"></a></h2>
+          <p>We have a dedicated news mailing list for general announcements (&lt;10 eMails per year) for the Rucio community. You can subscribe to <a href="mailto:rucio-news@cern.ch">rucio-news@cern.ch</a> directly with a CERN account, for external subscribers please send an eMail to <a href="mailto:rucio-news-subscribe@cern.ch">rucio-news-subscribe@cern.ch</a>.</p>
+
+
+          <h2>Email us <a class="icon solid fa-envelope" href="mailto:rucio-contact@cern.ch"></a></h2>
+          <p>We'd love to hear from you! Get in contact with us directly via email at <a href="mailto:rucio-contact@cern.ch">rucio-contact@cern.ch</a></p>
+
+
+          <h2>Social Media <a class="icon brands fa-mastodon" href="https://fosstodon.org/@rucio"></a></h2>
+          <p>Follow us on <a href="https://fosstodon.org/@rucio">Mastodon</a> to stay updated with the latest on Rucio!</p>
+
+      </div>
+
+      <!-- CTA -->
+      <section id="cta" class="wrapper style5">
+        <div class="inner">
+          <header>
+            <h2>Get in touch</h2>
+            <p>We are always happy to chat. You can drop us a mail and we will reply as quickly as possible.
+            </p>
+          </header>
+          <ul class="actions vertical">
+            <li><a href="contact.html" class="button special primary">Contact us</a></li>
+          </ul>
+
+        </div>
+      </section>
+
+      <!-- Footer -->
+      <footer id="footer">
+        <ul class="icons">
+          <li><a href="https://github.com/rucio" class="icon brands fa-github"><span class="label">GitHub</span></a></li>
+          <li><a href="https://fosstodon.org/@rucio" class="icon brands fa-mastodon"><span class="label">Mastodon</span></a></li>
+		  <li><a href="contact.html" class="icon solid fa-comments"><span class="label">Contact Us</span></a></li>
+          <li><a href="mailto:rucio-contact@cern.ch" class="icon solid fa-envelope"><span class="label">Email</span></a></li>
+        </ul>
+        <div class="cern-footer">
+          <a href="https://home.cern" class="cern-logo-link" title="CERN - Accelerating Science">
+            <img src="images/LogoOutline-White.svg" alt="CERN" class="cern-logo" />
+          </a>
+        </div>
+        <ul class="copyright">
+          <li>Website template by: <a href="https://html5up.net">HTML5 UP</a></li>
+          <li>Background image by: <a href="https://cds.cern.ch/record/1489958">CERN</a></li>
+        </ul>
+      </footer>
+
+    </section>
+  </div>
+
+  <!-- Scripts -->
+  <script src="assets/js/cern-toolbar.js"></script>
+  <script src="assets/js/jquery.min.js"></script>
+  <script src="assets/js/jquery.scrollex.min.js"></script>
+  <script src="assets/js/jquery.scrolly.min.js"></script>
+  <script src="assets/js/browser.min.js"></script>
+  <script src="assets/js/breakpoints.min.js"></script>
+  <script src="assets/js/util.js"></script>
+  <script src="assets/js/main.js"></script>
+  <!--[if lte IE 8]><script src="assets/js/ie/respond.min.js"></script><![endif]-->
+
+</body>
+
+</html>
+

--- a/contact.html
+++ b/contact.html
@@ -21,49 +21,7 @@
   <div id="page-wrapper">
 
     <!-- Header -->
-    <header id="header">
-      <a href="index.html">
-        <span id="logo-container">
-          <img src='images/wide_logo2.png' />
-        </span>
-      </a>
-
-      <nav id="nav-desktop">
-        <ul>
-          <li><a class="icon solid fa-code" href="https://github.com/rucio/rucio">&nbsp;Source</a></li>
-          <li>-</li>
-          <li><a class="icon solid fa-file-archive" href="https://rucio.cern.ch/documentation">&nbsp;Documentation</a></li>
-          <li>-</li>
-          <li><a class="icon solid fa-users" href="team.html">&nbsp;Team</a></li>
-          <li>-</li>
-          <li><a class="icon solid fa-globe" href="community.html">&nbsp;Community</a></li>
-          <li>-</li>
-          <li><a class="icon solid fa-comments" href="contact.html">&nbsp;Communication</a></li>
-          <li>-</li>
-          <li><a class="icon solid fa-book" href="publications.html">&nbsp;Publications</a></li>
-          <li>-</li>
-          <li><a class="icon solid fa-calendar" href="events.html">&nbsp;Events</a></li>
-        </ul>
-      </nav>
-      <nav id="nav">
-        <ul>
-          <li class="special">
-            <a href="#menu" class="menuToggle"></a>
-            <div id="menu">
-              <ul> 
-                <li><a class="icon solid fa-code" href="https://github.com/rucio/rucio">&nbsp;Source</a></li>
-                <li><a class="icon solid fa-file-archive" href="https://rucio.cern.ch/documentation">&nbsp;Documentation</a></li>
-                <li><a class="icon solid fa-users" href="team.html">&nbsp;Team</a></li>
-                <li><a class="icon solid fa-globe" href="community.html">&nbsp;Community</a></li>
-                <li><a class="icon solid fa-comments" href="contact.html">&nbsp;Communication</a></li>
-                <li><a class="icon solid fa-book" href="publications.html">&nbsp;Publications</a></li>
-                <li><a class="icon solid fa-calendar" href="events.html">&nbsp;Events</a></li>
-              </ul>
-            </div>
-          </li>
-        </ul>
-      </nav>
-    </header>
+    <div id="header-container"></div>
 
     <section id="communication" class="wrapper style5" style="margin-top: 4em;">
       <div class="inner">
@@ -108,37 +66,15 @@
       </section>
 
       <!-- Footer -->
-      <footer id="footer">
-        <ul class="icons">
-          <li><a href="https://github.com/rucio" class="icon brands fa-github"><span class="label">GitHub</span></a></li>
-          <li><a href="https://fosstodon.org/@rucio" class="icon brands fa-mastodon"><span class="label">Mastodon</span></a></li>
-		  <li><a href="contact.html" class="icon solid fa-comments"><span class="label">Contact Us</span></a></li>
-          <li><a href="mailto:rucio-contact@cern.ch" class="icon solid fa-envelope"><span class="label">Email</span></a></li>
-        </ul>
-        <div class="cern-footer">
-          <a href="https://home.cern" class="cern-logo-link" title="CERN - Accelerating Science">
-            <img src="images/LogoOutline-White.svg" alt="CERN" class="cern-logo" />
-          </a>
-        </div>
-        <ul class="copyright">
-          <li>Website template by: <a href="https://html5up.net">HTML5 UP</a></li>
-          <li>Background image by: <a href="https://cds.cern.ch/record/1489958">CERN</a></li>
-        </ul>
-      </footer>
+      <div id="footer-container"></div>
 
     </section>
   </div>
 
   <!-- Scripts -->
-  <script src="assets/js/cern-toolbar.js"></script>
-  <script src="assets/js/jquery.min.js"></script>
-  <script src="assets/js/jquery.scrollex.min.js"></script>
-  <script src="assets/js/jquery.scrolly.min.js"></script>
-  <script src="assets/js/browser.min.js"></script>
-  <script src="assets/js/breakpoints.min.js"></script>
-  <script src="assets/js/util.js"></script>
-  <script src="assets/js/main.js"></script>
-  <!--[if lte IE 8]><script src="assets/js/ie/respond.min.js"></script><![endif]-->
+  <script src="assets/js/header.js"></script>
+  <script src="assets/js/footer.js"></script>
+  <script src="assets/js/scripts.js"></script>
 
 </body>
 

--- a/events.html
+++ b/events.html
@@ -7,7 +7,7 @@
 <html>
 
 <head>
-  <title>Rucio - Scientific Data Management :: Publications</title>
+  <title>Rucio - Scientific Data Management :: Events</title>
   <meta charset="utf-8" />
   <meta name="viewport" content="width=device-width, initial-scale=1, user-scalable=no" />
   <link rel="stylesheet" href="assets/css/main.css" />
@@ -21,49 +21,7 @@
   <div id="page-wrapper">
 
     <!-- Header -->
-    <header id="header">
-      <a href="index.html">
-        <span id="logo-container">
-          <img src='images/wide_logo2.png' />
-        </span>
-      </a>
-
-      <nav id="nav-desktop">
-        <ul>
-          <li><a class="icon solid fa-code" href="https://github.com/rucio/rucio">&nbsp;Source</a></li>
-          <li>-</li>
-          <li><a class="icon solid fa-file-archive" href="https://rucio.cern.ch/documentation">&nbsp;Documentation</a></li>
-          <li>-</li>
-          <li><a class="icon solid fa-users" href="team.html">&nbsp;Team</a></li>
-          <li>-</li>
-          <li><a class="icon solid fa-globe" href="community.html">&nbsp;Community</a></li>
-          <li>-</li>
-          <li><a class="icon solid fa-comments" href="contact.html">&nbsp;Communication</a></li>
-          <li>-</li>
-          <li><a class="icon solid fa-book" href="publications.html">&nbsp;Publications</a></li>
-          <li>-</li>
-          <li><a class="icon solid fa-calendar" href="events.html">&nbsp;Events</a></li>
-        </ul>
-      </nav>
-      <nav id="nav">
-        <ul>
-          <li class="special">
-            <a href="#menu" class="menuToggle"></a>
-            <div id="menu">
-              <ul> 
-                <li><a class="icon solid fa-code" href="https://github.com/rucio/rucio">&nbsp;Source</a></li>
-                <li><a class="icon solid fa-file-archive" href="https://rucio.cern.ch/documentation">&nbsp;Documentation</a></li>
-                <li><a class="icon solid fa-users" href="team.html">&nbsp;Team</a></li>
-                <li><a class="icon solid fa-globe" href="community.html">&nbsp;Community</a></li>
-                <li><a class="icon solid fa-comments" href="contact.html">&nbsp;Communication</a></li>
-                <li><a class="icon solid fa-book" href="publications.html">&nbsp;Publications</a></li>
-                <li><a class="icon solid fa-calendar" href="events.html">&nbsp;Events</a></li>
-              </ul>
-            </div>
-          </li>
-        </ul>
-      </nav>
-    </header>
+    <div id="header-container"></div>
 
     <section id="events" class="wrapper style1 special">
       <div class="inner">
@@ -247,37 +205,14 @@
     </section>
 
     <!-- Footer -->
-    <footer id="footer">
-      <ul class="icons">
-        <li><a href="https://github.com/rucio" class="icon brands fa-github"><span class="label">GitHub</span></a></li>
-        <li><a href="https://fosstodon.org/@rucio" class="icon brands fa-mastodon"><span class="label">GitHub</span></a></li>
-		<li><a href="http://rucio.cern.ch/documentation/contact_us" class="icon solid fa-comments"><span class="label">Contact
-              Us</span></a></li>
-        <li><a href="mailto:rucio-contact@cern.ch" class="icon solid fa-envelope"><span class="label">Email</span></a></li>
-      </ul>
-      <div class="cern-footer">
-        <a href="https://home.cern" class="cern-logo-link" title="CERN - Accelerating Science">
-          <img src="images/LogoOutline-White.svg" alt="CERN" class="cern-logo" />
-        </a>
-      </div>
-      <ul class="copyright">
-        <li>Website template by: <a href="https://html5up.net">HTML5 UP</a></li>
-        <li>Background image by: <a href="https://cds.cern.ch/record/1489958">CERN</a></li>
-      </ul>
-    </footer>
+    <div id="footer-container"></div>
 
   </div>
 
 	<!-- Scripts -->
-    <script src="assets/js/cern-toolbar.js"></script>
-    <script src="assets/js/jquery.min.js"></script>
-    <script src="assets/js/jquery.scrollex.min.js"></script>
-    <script src="assets/js/jquery.scrolly.min.js"></script>
-    <script src="assets/js/browser.min.js"></script>
-    <script src="assets/js/breakpoints.min.js"></script>
-    <script src="assets/js/util.js"></script>
-    <script src="assets/js/main.js"></script>
-    <!--[if lte IE 8]><script src="assets/js/ie/respond.min.js"></script><![endif]-->
+    <script src="assets/js/header.js"></script>
+    <script src="assets/js/footer.js"></script>
+    <script src="assets/js/scripts.js"></script>
 
 </body>
 

--- a/events.html
+++ b/events.html
@@ -38,7 +38,7 @@
           <li>-</li>
           <li><a class="icon solid fa-globe" href="community.html">&nbsp;Community</a></li>
           <li>-</li>
-          <li><a class="icon solid fa-comments" href="https://rucio.cern.ch/documentation/contact_us">&nbsp;Communication</a></li>
+          <li><a class="icon solid fa-comments" href="contact.html">&nbsp;Communication</a></li>
           <li>-</li>
           <li><a class="icon solid fa-book" href="publications.html">&nbsp;Publications</a></li>
           <li>-</li>
@@ -55,7 +55,7 @@
                 <li><a class="icon solid fa-file-archive" href="https://rucio.cern.ch/documentation">&nbsp;Documentation</a></li>
                 <li><a class="icon solid fa-users" href="team.html">&nbsp;Team</a></li>
                 <li><a class="icon solid fa-globe" href="community.html">&nbsp;Community</a></li>
-                <li><a class="icon solid fa-comments" href="https://rucio.cern.ch/documentation/contact_us">&nbsp;Communication</a></li>
+                <li><a class="icon solid fa-comments" href="contact.html">&nbsp;Communication</a></li>
                 <li><a class="icon solid fa-book" href="publications.html">&nbsp;Publications</a></li>
                 <li><a class="icon solid fa-calendar" href="events.html">&nbsp;Events</a></li>
               </ul>
@@ -239,7 +239,7 @@
           <p>We are always happy to chat. You can drop us a mail and we will reply as quickly as possible.</p>
         </header>
         <ul class="actions vertical">
-          <li><a href="https://rucio.cern.ch/documentation/contact_us" class="button special primary">Contact us</a>
+          <li><a href="contact.html" class="button special primary">Contact us</a>
           </li>
         </ul>
 

--- a/index.html
+++ b/index.html
@@ -40,7 +40,7 @@
           <li>-</li>
           <li><a class="icon solid fa-globe" href="community.html">&nbsp;Community</a></li>
           <li>-</li>
-          <li><a class="icon solid fa-comments" href="https://rucio.cern.ch/documentation/contact_us">&nbsp;Communication</a></li>
+          <li><a class="icon solid fa-comments" href="contact.html">&nbsp;Communication</a></li>
           <li>-</li>
           <li><a class="icon solid fa-book" href="publications.html">&nbsp;Publications</a></li>
           <li>-</li>
@@ -58,8 +58,7 @@
                     href="https://rucio.cern.ch/documentation">&nbsp;Documentation</a></li>
                 <li><a class="icon solid fa-users" href="team.html">&nbsp;Team</a></li>
                 <li><a class="icon solid fa-globe" href="community.html">&nbsp;Community</a></li>
-                <li><a class="icon solid fa-comments"
-                    href="https://rucio.cern.ch/documentation/contact_us">&nbsp;Communication</a></li>
+                <li><a class="icon solid fa-comments" href="contact.html">&nbsp;Communication</a></li>
                 <li><a class="icon solid fa-book" href="publications.html">&nbsp;Publications</a></li>
                 <li><a class="icon solid fa-calendar" href="events.html">&nbsp;Events</a></li>
               </ul>
@@ -215,7 +214,7 @@
           <p>We are always happy to chat. You can drop us a mail and we will reply as quickly as possible.</p>
         </header>
         <ul class="actions vertical">
-          <li><a href="https://rucio.cern.ch/documentation/contact_us" class="button special primary">Contact us</a></li>
+          <li><a href="contact.html" class="button special primary">Contact us</a></li>
         </ul>
 
       </div>
@@ -226,9 +225,7 @@
       <ul class="icons">
         <li><a href="https://github.com/rucio" class="icon brands fa-github"><span class="label">GitHub</span></a></li>
         <li><a href="https://fosstodon.org/@rucio" class="icon brands fa-mastodon"><span class="label">GitHub</span></a></li>
-        <li><a href="http://rucio.cern.ch/documentation/contact_us" class="icon solid fa-comments"><span
-              class="label">Contact
-              Us</span></a></li>
+        <li><a href="contact.html" class="icon solid fa-comments"><span class="label">Contact Us</span></a></li>
         <li><a href="mailto:rucio-contact@cern.ch" class="icon solid fa-envelope"><span class="label">Email</span></a>
         </li>
       </ul>

--- a/index.html
+++ b/index.html
@@ -23,50 +23,7 @@
   <div id="page-wrapper">
 
     <!-- Header -->
-    <header id="header" class="alt">
-      <a href="index.html">
-        <span id="logo-container">
-          <img src='images/wide_logo2.png' />
-        </span>
-      </a>
-
-      <nav id="nav-desktop">
-        <ul>
-          <li><a class="icon solid fa-code" href="https://github.com/rucio/rucio">&nbsp;Source</a></li>
-          <li>-</li>
-          <li><a class="icon solid fa-file-archive" href="https://rucio.cern.ch/documentation">&nbsp;Documentation</a></li>
-          <li>-</li>
-          <li><a class="icon solid fa-users" href="team.html">&nbsp;Team</a></li>
-          <li>-</li>
-          <li><a class="icon solid fa-globe" href="community.html">&nbsp;Community</a></li>
-          <li>-</li>
-          <li><a class="icon solid fa-comments" href="contact.html">&nbsp;Communication</a></li>
-          <li>-</li>
-          <li><a class="icon solid fa-book" href="publications.html">&nbsp;Publications</a></li>
-          <li>-</li>
-          <li><a class="icon solid fa-calendar" href="events.html">&nbsp;Events</a></li>
-        </ul>
-      </nav>
-      <nav id="nav">
-        <ul>
-          <li class="special">
-            <a href="#menu" class="menuToggle"></a>
-            <div id="menu">
-              <ul>
-                <li><a class="icon solid fa-code" href="https://github.com/rucio/rucio">&nbsp;Source</a></li>
-                <li><a class="icon solid fa-file-archive"
-                    href="https://rucio.cern.ch/documentation">&nbsp;Documentation</a></li>
-                <li><a class="icon solid fa-users" href="team.html">&nbsp;Team</a></li>
-                <li><a class="icon solid fa-globe" href="community.html">&nbsp;Community</a></li>
-                <li><a class="icon solid fa-comments" href="contact.html">&nbsp;Communication</a></li>
-                <li><a class="icon solid fa-book" href="publications.html">&nbsp;Publications</a></li>
-                <li><a class="icon solid fa-calendar" href="events.html">&nbsp;Events</a></li>
-              </ul>
-            </div>
-          </li>
-        </ul>
-      </nav>
-    </header>
+    <div id="header-container"></div>
 
     <!-- Banner -->
     <section id="banner">
@@ -221,37 +178,14 @@
     </section>
 
     <!-- Footer -->
-    <footer id="footer">
-      <ul class="icons">
-        <li><a href="https://github.com/rucio" class="icon brands fa-github"><span class="label">GitHub</span></a></li>
-        <li><a href="https://fosstodon.org/@rucio" class="icon brands fa-mastodon"><span class="label">GitHub</span></a></li>
-        <li><a href="contact.html" class="icon solid fa-comments"><span class="label">Contact Us</span></a></li>
-        <li><a href="mailto:rucio-contact@cern.ch" class="icon solid fa-envelope"><span class="label">Email</span></a>
-        </li>
-      </ul>
-      <div class="cern-footer">
-        <a href="https://home.cern" class="cern-logo-link" title="CERN - Accelerating Science">
-          <img src="images/LogoOutline-White.svg" alt="CERN" class="cern-logo" />
-        </a>
-      </div>
-      <ul class="copyright">
-        <li>Website template by: <a href="http://html5up.net">HTML5 UP</a></li>
-        <li>Background image by: <a href="https://cds.cern.ch/record/1489958">CERN</a></li>
-      </ul>
-    </footer>
+    <div id="footer-container"></div>
 
   </div>
 
   <!-- Scripts -->
-  <script src="assets/js/cern-toolbar.js"></script>
-  <script src="assets/js/jquery.min.js"></script>
-  <script src="assets/js/jquery.scrollex.min.js"></script>
-  <script src="assets/js/jquery.scrolly.min.js"></script>
-  <script src="assets/js/browser.min.js"></script>
-  <script src="assets/js/breakpoints.min.js"></script>
-  <script src="assets/js/util.js"></script>
-  <script src="assets/js/main.js"></script>
-  <!--[if lte IE 8]><script src="assets/js/ie/respond.min.js"></script><![endif]-->
+  <script src="assets/js/header.js"></script>
+  <script src="assets/js/footer.js"></script>
+  <script src="assets/js/scripts.js"></script>
 
 </body>
 

--- a/publications.html
+++ b/publications.html
@@ -38,7 +38,7 @@
           <li>-</li>
           <li><a class="icon solid fa-globe" href="community.html">&nbsp;Community</a></li>
           <li>-</li>
-          <li><a class="icon solid fa-comments" href="https://rucio.cern.ch/documentation/contact_us">&nbsp;Communication</a></li>
+          <li><a class="icon solid fa-comments" href="contact.html">&nbsp;Communication</a></li>
           <li>-</li>
           <li><a class="icon solid fa-book" href="publications.html">&nbsp;Publications</a></li>
           <li>-</li>
@@ -55,7 +55,7 @@
                 <li><a class="icon solid fa-file-archive" href="https://rucio.cern.ch/documentation">&nbsp;Documentation</a></li>
                 <li><a class="icon solid fa-users" href="team.html">&nbsp;Team</a></li>
                 <li><a class="icon solid fa-globe" href="community.html">&nbsp;Community</a></li>
-                <li><a class="icon solid fa-comments" href="https://rucio.cern.ch/documentation/contact_us">&nbsp;Communication</a></li>
+                <li><a class="icon solid fa-comments" href="contact.html">&nbsp;Communication</a></li>
                 <li><a class="icon solid fa-book" href="publications.html">&nbsp;Publications</a></li>
                 <li><a class="icon solid fa-calendar" href="events.html">&nbsp;Events</a></li>
               </ul>
@@ -242,7 +242,7 @@
           <p>We are always happy to chat. You can drop us a mail and we will reply as quickly as possible.</p>
         </header>
         <ul class="actions vertical">
-          <li><a href="https://rucio.cern.ch/documentation/contact_us" class="button special primary">Contact us</a>
+          <li><a href="contact.html" class="button special primary">Contact us</a>
           </li>
         </ul>
 

--- a/publications.html
+++ b/publications.html
@@ -21,49 +21,7 @@
   <div id="page-wrapper">
 
     <!-- Header -->
-    <header id="header">
-      <a href="index.html">
-        <span id="logo-container">
-          <img src='images/wide_logo2.png' />
-        </span>
-      </a>
-
-      <nav id="nav-desktop">
-        <ul>
-          <li><a class="icon solid fa-code" href="https://github.com/rucio/rucio">&nbsp;Source</a></li>
-          <li>-</li>
-          <li><a class="icon solid fa-file-archive" href="https://rucio.cern.ch/documentation">&nbsp;Documentation</a></li>
-          <li>-</li>
-          <li><a class="icon solid fa-users" href="team.html">&nbsp;Team</a></li>
-          <li>-</li>
-          <li><a class="icon solid fa-globe" href="community.html">&nbsp;Community</a></li>
-          <li>-</li>
-          <li><a class="icon solid fa-comments" href="contact.html">&nbsp;Communication</a></li>
-          <li>-</li>
-          <li><a class="icon solid fa-book" href="publications.html">&nbsp;Publications</a></li>
-          <li>-</li>
-          <li><a class="icon solid fa-calendar" href="events.html">&nbsp;Events</a></li>
-        </ul>
-      </nav>
-      <nav id="nav">
-        <ul>
-          <li class="special">
-            <a href="#menu" class="menuToggle"></a>
-            <div id="menu">
-              <ul> 
-                <li><a class="icon solid fa-code" href="https://github.com/rucio/rucio">&nbsp;Source</a></li>
-                <li><a class="icon solid fa-file-archive" href="https://rucio.cern.ch/documentation">&nbsp;Documentation</a></li>
-                <li><a class="icon solid fa-users" href="team.html">&nbsp;Team</a></li>
-                <li><a class="icon solid fa-globe" href="community.html">&nbsp;Community</a></li>
-                <li><a class="icon solid fa-comments" href="contact.html">&nbsp;Communication</a></li>
-                <li><a class="icon solid fa-book" href="publications.html">&nbsp;Publications</a></li>
-                <li><a class="icon solid fa-calendar" href="events.html">&nbsp;Events</a></li>
-              </ul>
-            </div>
-          </li>
-        </ul>
-      </nav>
-    </header>
+    <div id="header-container"></div>
 
     <section id="publications" class="wrapper style1 special">
       <div class="inner">
@@ -250,36 +208,14 @@
     </section>
 
     <!-- Footer -->
-    <footer id="footer">
-      <ul class="icons">
-        <li><a href="https://github.com/rucio" class="icon brands fa-github"><span class="label">GitHub</span></a></li>
-        <li><a href="https://fosstodon.org/@rucio" class="icon brands fa-mastodon"><span class="label">GitHub</span></a></li>
-		<li><a href="http://rucio.cern.ch/documentation/contact_us" class="icon solid fa-comments"><span class="label">Contact Us</span></a></li>
-        <li><a href="mailto:rucio-contact@cern.ch" class="icon solid fa-envelope"><span class="label">Email</span></a></li>
-      </ul>
-      <div class="cern-footer">
-        <a href="https://home.cern" class="cern-logo-link" title="CERN - Accelerating Science">
-          <img src="images/LogoOutline-White.svg" alt="CERN" class="cern-logo" />
-        </a>
-      </div>
-      <ul class="copyright">
-        <li>Website template by: <a href="http://html5up.net">HTML5 UP</a></li>
-        <li>Background image by: <a href="https://cds.cern.ch/record/1489958">CERN</a></li>
-      </ul>
-    </footer>
+    <div id="footer-container"></div>
 
   </div>
 
 	<!-- Scripts -->
-    <script src="assets/js/cern-toolbar.js"></script>
-    <script src="assets/js/jquery.min.js"></script>
-    <script src="assets/js/jquery.scrollex.min.js"></script>
-    <script src="assets/js/jquery.scrolly.min.js"></script>
-    <script src="assets/js/browser.min.js"></script>
-    <script src="assets/js/breakpoints.min.js"></script>
-    <script src="assets/js/util.js"></script>
-    <script src="assets/js/main.js"></script>
-  <!--[if lte IE 8]><script src="assets/js/ie/respond.min.js"></script><![endif]-->
+    <script src="assets/js/header.js"></script>
+    <script src="assets/js/footer.js"></script>
+    <script src="assets/js/scripts.js"></script>
 
 </body>
 

--- a/team.html
+++ b/team.html
@@ -21,49 +21,7 @@
   <div id="page-wrapper">
 
     <!-- Header -->
-    <header id="header">
-      <a href="index.html">
-        <span id="logo-container">
-          <img src='images/wide_logo2.png' />
-        </span>
-      </a>
-
-      <nav id="nav-desktop">
-        <ul>
-          <li><a class="icon solid fa-code" href="https://github.com/rucio/rucio">&nbsp;Source</a></li>
-          <li>-</li>
-          <li><a class="icon solid fa-file-archive" href="https://rucio.cern.ch/documentation">&nbsp;Documentation</a></li>
-          <li>-</li>
-          <li><a class="icon solid fa-users" href="team.html">&nbsp;Team</a></li>
-          <li>-</li>
-          <li><a class="icon solid fa-globe" href="community.html">&nbsp;Community</a></li>
-          <li>-</li>
-          <li><a class="icon solid fa-comments" href="contact.html">&nbsp;Communication</a></li>
-          <li>-</li>
-          <li><a class="icon solid fa-book" href="publications.html">&nbsp;Publications</a></li>
-          <li>-</li>
-          <li><a class="icon solid fa-calendar" href="events.html">&nbsp;Events</a></li>
-        </ul>
-      </nav>
-      <nav id="nav">
-        <ul>
-          <li class="special">
-            <a href="#menu" class="menuToggle"></a>
-            <div id="menu">
-              <ul> 
-                <li><a class="icon solid fa-code" href="https://github.com/rucio/rucio">&nbsp;Source</a></li>
-                <li><a class="icon solid fa-file-archive" href="https://rucio.cern.ch/documentation">&nbsp;Documentation</a></li>
-                <li><a class="icon solid fa-users" href="team.html">&nbsp;Team</a></li>
-                <li><a class="icon solid fa-globe" href="community.html">&nbsp;Community</a></li>
-                <li><a class="icon solid fa-comments" href="contact.html">&nbsp;Communication</a></li>
-                <li><a class="icon solid fa-book" href="publications.html">&nbsp;Publications</a></li>
-                <li><a class="icon solid fa-calendar" href="events.html">&nbsp;Events</a></li>
-              </ul>
-            </div>
-          </li>
-        </ul>
-      </nav>
-    </header>
+    <div id="header-container"></div>
 
     <section id="team" class="wrapper style5">
       <div class="inner">
@@ -577,36 +535,14 @@ In his spare time, Hugo enjoys technical diving in cold lakes and restoring clas
       </section>
 
       <!-- Footer -->
-      <footer id="footer">
-        <ul class="icons">
-          <li><a href="https://github.com/rucio" class="icon brands fa-github"><span class="label">GitHub</span></a></li>
-          <li><a href="https://fosstodon.org/@rucio" class="icon brands fa-mastodon"><span class="label">GitHub</span></a></li>
-		  <li><a href="http://rucio.cern.ch/documentation/contact_us" class="icon solid fa-comments"><span class="label">Contact Us</span></a></li>
-          <li><a href="mailto:rucio-contact@cern.ch" class="icon solid fa-envelope"><span class="label">Email</span></a></li>
-        </ul>
-        <div class="cern-footer">
-          <a href="https://home.cern" class="cern-logo-link" title="CERN - Accelerating Science">
-            <img src="images/LogoOutline-White.svg" alt="CERN" class="cern-logo" />
-          </a>
-        </div>
-        <ul class="copyright">
-          <li>Website template by: <a href="http://html5up.net">HTML5 UP</a></li>
-          <li>Background image by: <a href="https://cds.cern.ch/record/1489958">CERN</a></li>
-        </ul>
-      </footer>
+      <div id="footer-container"></div>
 
     </section>
   </div>
 		<!-- Scripts -->
-    <script src="assets/js/cern-toolbar.js"></script>
-    <script src="assets/js/jquery.min.js"></script>
-    <script src="assets/js/jquery.scrollex.min.js"></script>
-    <script src="assets/js/jquery.scrolly.min.js"></script>
-    <script src="assets/js/browser.min.js"></script>
-    <script src="assets/js/breakpoints.min.js"></script>
-    <script src="assets/js/util.js"></script>
-    <script src="assets/js/main.js"></script>
-    <!--[if lte IE 8]><script src="assets/js/ie/respond.min.js"></script><![endif]-->
+    <script src="assets/js/header.js"></script>
+    <script src="assets/js/footer.js"></script>
+    <script src="assets/js/scripts.js"></script>
 
 </body>
 

--- a/team.html
+++ b/team.html
@@ -38,7 +38,7 @@
           <li>-</li>
           <li><a class="icon solid fa-globe" href="community.html">&nbsp;Community</a></li>
           <li>-</li>
-          <li><a class="icon solid fa-comments" href="https://rucio.cern.ch/documentation/contact_us">&nbsp;Communication</a></li>
+          <li><a class="icon solid fa-comments" href="contact.html">&nbsp;Communication</a></li>
           <li>-</li>
           <li><a class="icon solid fa-book" href="publications.html">&nbsp;Publications</a></li>
           <li>-</li>
@@ -55,7 +55,7 @@
                 <li><a class="icon solid fa-file-archive" href="https://rucio.cern.ch/documentation">&nbsp;Documentation</a></li>
                 <li><a class="icon solid fa-users" href="team.html">&nbsp;Team</a></li>
                 <li><a class="icon solid fa-globe" href="community.html">&nbsp;Community</a></li>
-                <li><a class="icon solid fa-comments" href="https://rucio.cern.ch/documentation/contact_us">&nbsp;Communication</a></li>
+                <li><a class="icon solid fa-comments" href="contact.html">&nbsp;Communication</a></li>
                 <li><a class="icon solid fa-book" href="publications.html">&nbsp;Publications</a></li>
                 <li><a class="icon solid fa-calendar" href="events.html">&nbsp;Events</a></li>
               </ul>
@@ -570,7 +570,7 @@ In his spare time, Hugo enjoys technical diving in cold lakes and restoring clas
             </p>
           </header>
           <ul class="actions vertical">
-            <li><a href="https://rucio.cern.ch/documentation/contact_us" class="button special primary">Contact us</a></li>
+            <li><a href="contact.html" class="button special primary">Contact us</a></li>
           </ul>
 
         </div>


### PR DESCRIPTION
Fixes #80 
This PR migrates the communication section from the contact page of [Rucio Docs](https://rucio.cern.ch/documentation/contact_us) to Rucio Website. This PR also refactors the duplicate code written for every page into a single component and reuses it. 

Screenshot:
<img width="2515" height="1289" alt="image" src="https://github.com/user-attachments/assets/aa99aff7-2426-471e-85b4-c3d79e3ec8db" />
